### PR TITLE
Fix for wide-Unicode little-endian Py3k.

### DIFF
--- a/py-appscript/trunk/appscript_2x/ext/ae.c
+++ b/py-appscript/trunk/appscript_2x/ext/ae.c
@@ -1032,21 +1032,12 @@ static int AE_GetCFStringRef(PyObject *v, CFStringRef *p_itself)
 		return 1;
 	}
 	if (PyUnicode_Check(v)) {
-#ifdef Py_UNICODE_WIDE
-	CFIndex size = PyUnicode_GET_DATA_SIZE(v);
-	UTF32Char *unichars = PyUnicode_AsUnicode(v);
-	*p_itself = CFStringCreateWithBytes((CFAllocatorRef)NULL,
-										unichars,
-										size,
-										kCFStringEncodingUTF32, // 10.4+
-										false); // ?
-#else
-		CFIndex size = PyUnicode_GetSize(v);
-		UniChar *unichars = PyUnicode_AsUnicode(v);
-		if (!unichars) return 0;
-		*p_itself = CFStringCreateWithCharacters((CFAllocatorRef)NULL, unichars, size);
-#endif
-		return 1;
+            char *cStr;
+            if (!PyArg_Parse(v, "es", NULL, &cStr))
+                return 0;
+            *p_itself = CFStringCreateWithCString((CFAllocatorRef)NULL, cStr, kCFStringEncodingUTF8);
+            PyMem_Free(cStr);
+            return 1;
 	}
 	PyErr_SetString(PyExc_TypeError, "str/unicode required");
 	return 0;

--- a/py-appscript/trunk/appscript_3x/ext/ae.c
+++ b/py-appscript/trunk/appscript_3x/ext/ae.c
@@ -1010,21 +1010,12 @@ static int AE_GetCFStringRef(PyObject *v, CFStringRef *p_itself)
 		return 1;
 	}
 	if (PyUnicode_Check(v)) {
-#ifdef Py_UNICODE_WIDE
-	CFIndex size = PyUnicode_GET_DATA_SIZE(v);
-	UTF32Char *unichars = PyUnicode_AsUnicode(v);
-	*p_itself = CFStringCreateWithBytes((CFAllocatorRef)NULL,
-										unichars,
-										size,
-										kCFStringEncodingUTF32, // 10.4+
-										false); // ?
-#else
-		CFIndex size = PyUnicode_GetSize(v);
-		UniChar *unichars = PyUnicode_AsUnicode(v);
-		if (!unichars) return 0;
-		*p_itself = CFStringCreateWithCharacters((CFAllocatorRef)NULL, unichars, size);
-#endif
-		return 1;
+            char *cStr;
+            if (!PyArg_Parse(v, "es", NULL, &cStr))
+                return 0;
+            *p_itself = CFStringCreateWithCString((CFAllocatorRef)NULL, cStr, kCFStringEncodingUTF8);
+            PyMem_Free(cStr);
+            return 1;
 	}
 	PyErr_SetString(PyExc_TypeError, "str/unicode required");
 	return 0;


### PR DESCRIPTION
- Inside ae.c, AE_GetCFStringRef assumes that the data inside a wide
  PyUnicode is in the same endianness that CF wants. But PyUnicode is
  native-endian, kCFStringEncodingUTF32 is big-endian (if no BOM). We
  could write code to explcitly use kCFStringEncodingUTF32[LE|BE] as
  appropriate, or tack on a BOM to the start of a copy of the UTF-32
  and use kCFStringEncodingUTF32 as-is, or various other possibilities...
  but it's a lot simpler to use UTF8, and I doubt the performance will
  ever be an issue.
