### PR TITLE
objc: Added a way to truncate descriptions of long data descriptors.

### DIFF
--- a/objc-appscript/trunk/src/Appscript/objectrenderer.h
+++ b/objc-appscript/trunk/src/Appscript/objectrenderer.h
@@ -12,5 +12,7 @@
 
 +(NSString *)formatObject:(id)obj;
 
++(void)setDataDescriptionTruncation:(NSUInteger)maxBytes;
+
 @end
 

--- a/objc-appscript/trunk/src/Appscript/objectrenderer.m
+++ b/objc-appscript/trunk/src/Appscript/objectrenderer.m
@@ -5,6 +5,7 @@
 
 #import "objectrenderer.h"
 
+static NSUInteger dataDescriptionTruncation = (NSUInteger)-1;
 
 @implementation AEMObjectRenderer
 
@@ -103,8 +104,26 @@
 		[self formatObject: [obj description] indent: @"" result: result];
 		[result appendString: @"]"];
 	
-	} else
-		[result appendFormat: @"%@", obj];
+	} else if ([obj isKindOfClass:[NSAppleEventDescriptor class]]) {
+		NSString *s = [obj description];
+                if ([s hasPrefix:@"<NSAppleEventDescriptor:"]) {
+                	NSArray *bits = [s componentsSeparatedByString:@"$"];
+                        if ([bits count] == 3) {
+                        	NSString *d = [bits objectAtIndex:1];
+                                NSUInteger length = [d length];
+                                if (length / 2 > dataDescriptionTruncation) {
+                                	s = [NSString stringWithFormat:@"%@%d:$%@...$%@",
+                                             [bits objectAtIndex:0], 
+                                             (int)length / 2,
+                                             [d substringToIndex:dataDescriptionTruncation * 2],
+                                             [bits objectAtIndex:2]];
+                                }
+                        }
+                }
+                [result appendString:s];
+        } else {
+        	[result appendFormat:@"%@", obj];
+        }
 }
 
 
@@ -117,5 +136,8 @@
 	return result;
 }
 
++(void)setDataDescriptionTruncation:(NSUInteger)maxBytes {
+    dataDescriptionTruncation = maxBytes;
+}
 
 @end


### PR DESCRIPTION
- Added one method, `+[AEMObjectRenderer setDataDescriptionTruncation:]`.
  When set to `maxBytes`, this affects the description of any descriptor
  that describes as hex bytes, so that only the first `maxBytes` will be
  displayed, followed by an ellipsis.
- This is primarily useful when debugging AE interfaces that send
  large hunks of binary data around, such as iTunes cover art. The
  first few bytes of the artwork's data object are enough to tell
  whether you're getting a PNG or a PICT; the remaining 200K chars do
  nothing but make the logs harder to read and search.
- Since the data descriptor may be embedded in some other object, the
  most reasonable place to put the truncation is inside its
  `description` (or, rather, in `+[formatObject:indent:result:]`, the
  recursive function that does the actual formatting underlying
  `description`).
- Truncation is off by default, because sometimes you _do_ want all
  200K (e.g., so you can parse the logs, unhexlify the bytes, save
  them as a file, and see if they're the PICT you expected).
