### PR TITLE
objc: Some methods did not check for null NSError** param.

### DIFF
--- a/objc-appscript/trunk/src/Appscript/application.m
+++ b/objc-appscript/trunk/src/Appscript/application.m
@@ -17,12 +17,12 @@
 							bundleID:(NSString *)bundleID
 								name:(NSString *)name
 							   error:(out NSError **)error {
-	OSErr err;
+	OSStatus err;
 	CFURLRef outAppURL;
 	NSString *errorDescription;
 	NSDictionary *errorInfo;
 	
-	*error = nil;
+	if (error) *error = nil;
 	err = LSFindApplicationForInfo(creator,
 								   (CFStringRef)bundleID,
 								   (CFStringRef)name,
@@ -70,7 +70,7 @@
 	NSDictionary *errorInfo;
 	pid_t pid;
 	
-	*error = nil;
+	if (error) *error = nil;
 	if (!fileURL || !CFURLGetFSRef((CFURLRef)fileURL, &desired)) {
 		err = errFSBadFSRef;
 		goto error;
@@ -155,7 +155,7 @@ error:
 	NSString *errorDescription;
 	NSDictionary *errorInfo;
 	
-	*error = nil;
+	if (error) *error = nil;
 	if (!fileURL || !CFURLGetFSRef((CFURLRef)fileURL, &fsRef)) {
 		err = fnfErr;
 		goto error;


### PR DESCRIPTION
- Many of the methods in `AEMApplication`, `AEMEvent`, etc. follow
  the usual ObjC idiom of taking an optional `NSError** error`, but
  some of the methods in `AEMApplication` are missing checks for
  null, and therefore crash on `*error=nil`.

For example:

``` objc
[AEMApplication findApplicationForCreator:kLSUnknownCreator
                                 bundleID:nil
                                     name:@"NonexistentApp"
                                    error:nil];
```
