### PR TITLE
objc: Fix a number of 64-bit errors.

### DIFF
--- a/objc-appscript/trunk/src/Appscript/appdata.m
+++ b/objc-appscript/trunk/src/Appscript/appdata.m
@@ -57,7 +57,7 @@
 			target = [[aemApplicationClass alloc] initWithURL: targetData error: error];
 			break;
 		case kASTargetPID:
-			target = [[aemApplicationClass alloc] initWithPID: [targetData unsignedLongValue]];
+			target = [[aemApplicationClass alloc] initWithPID: (pid_t)[targetData unsignedLongValue]];
 			break;
 		case kASTargetDescriptor:
 			target = [[aemApplicationClass alloc] initWithDescriptor: targetData];
@@ -90,7 +90,7 @@
 				result = [AEMApplication processExistsForEppcURL: targetData];
 			break;
 		case kASTargetPID:
-			result = [AEMApplication processExistsForPID: [targetData unsignedLongValue]];
+			result = [AEMApplication processExistsForPID: (pid_t)[targetData unsignedLongValue]];
 			break;
 		case kASTargetDescriptor:
 			result = [AEMApplication processExistsForDescriptor: targetData];

--- a/objc-appscript/trunk/src/Appscript/application.m
+++ b/objc-appscript/trunk/src/Appscript/application.m
@@ -85,8 +85,8 @@
 	return pid;
 error:
 	if (error) {
-		errorDescription = [NSString stringWithFormat: @"Can't find process ID for application %@: %@ (%i)", 
-														fileURL, ASDescriptionForError(err), err];
+		errorDescription = [NSString stringWithFormat: @"Can't find process ID for application %@: %@ (%ld)",
+														fileURL, ASDescriptionForError(err), (long)err];
 		errorInfo = [NSDictionary dictionaryWithObjectsAndKeys: 
 				errorDescription, NSLocalizedDescriptionKey,
 				[NSNumber numberWithInt: err], kASErrorNumberKey,
@@ -172,8 +172,8 @@ error:
 	return pid;
 error:
 	if (error) {
-		errorDescription = [NSString stringWithFormat: @"Can't launch application %@: %@ (%i)", 
-														fileURL, ASDescriptionForError(err), err];
+		errorDescription = [NSString stringWithFormat: @"Can't launch application %@: %@ (%ld)",
+														fileURL, ASDescriptionForError(err), (long)err];
 		errorInfo = [NSDictionary dictionaryWithObjectsAndKeys: 
 				errorDescription, NSLocalizedDescriptionKey,
 				[NSNumber numberWithInt: err], kASErrorNumberKey,

--- a/objc-appscript/trunk/src/Appscript/base.h
+++ b/objc-appscript/trunk/src/Appscript/base.h
@@ -11,7 +11,7 @@
 
 @interface AEMQuery : NSObject <AEMSelfPackingProtocol> {
 	NSAppleEventDescriptor *cachedDesc;
-	unsigned cachedHash;
+	NSUInteger cachedHash;
 }
 
 // set cached descriptor; performance optimisation, used internally by AEMCodecs

--- a/objc-appscript/trunk/src/Appscript/codecs.m
+++ b/objc-appscript/trunk/src/Appscript/codecs.m
@@ -460,7 +460,7 @@
 
 - (id)unpackAEList:(NSAppleEventDescriptor *)desc {
 	NSMutableArray *result;
-	int i, length;
+	NSUInteger i, length;
 	
 	result = [NSMutableArray array];
 	length = [desc numberOfItems];
@@ -476,7 +476,7 @@
 	AEKeyword key;
 	const AEDesc *record;
 	AEDesc valueAEDesc;
-	int i, j, length, length2;
+	NSInteger i, j, length, length2;
 	id value;
 	
 	result = [NSMutableDictionary dictionary];

--- a/objc-appscript/trunk/src/Appscript/command.m
+++ b/objc-appscript/trunk/src/Appscript/command.m
@@ -283,7 +283,7 @@ fail:
 	}
 	// format attributes
 	if (timeout != kAEDefaultTimeout)
-		result = [NSString stringWithFormat: @"[%@ timeout: %i]", result, timeout / 60];
+		result = [NSString stringWithFormat: @"[%@ timeout: %ld]", result, (long)(timeout / 60)];
 	if (sendMode != (kAEWaitReply | kAECanSwitchLayer)) {
 		if (sendMode & ~(kAEWaitReply | kAEQueueReply | kAENoReply) == kAECanSwitchLayer) {
 			if (sendMode & kAENoReply)
@@ -291,10 +291,10 @@ fail:
 			if (sendMode & kAEQueueReply)
 				result = [NSString stringWithFormat: @"[%@ queueReply]", result];
 		} else
-			result = [NSString stringWithFormat: @"[%@ sendMode: %#08x]", result, sendMode];
+			result = [NSString stringWithFormat: @"[%@ sendMode: %#08lx]", result, (long)sendMode];
 	}
 	if (considsAndIgnoresFlags != kAECaseIgnoreMask)
-		result = [NSString stringWithFormat: @"[%@ considering: %#08x]", result, considsAndIgnoresFlags];
+		result = [NSString stringWithFormat: @"[%@ considering: %#08lx]", result, (long)considsAndIgnoresFlags];
 	// format unpacking options
 	[AS_event getUnpackFormat: &format type: &type];
 	if (format == kAEMUnpackAsItem && type != typeWildCard)

--- a/objc-appscript/trunk/src/Appscript/event.m
+++ b/objc-appscript/trunk/src/Appscript/event.m
@@ -223,7 +223,8 @@ static ASEventAttributeDescription attributeKeys[] = {
  */
 
 - (id)sendWithMode:(AESendMode)sendMode timeout:(long)timeoutInTicks error:(out NSError **)error {
-	OSErr err, errorNumber;
+	OSErr err;
+	OSStatus errorNumber;
 	NSString *errorString, *errorDescription;
 	NSDictionary *errorInfo;
 	AEDesc replyDesc = {typeNull, NULL};
@@ -253,8 +254,8 @@ static ASEventAttributeDescription attributeKeys[] = {
 		}
 		// for any other Apple Event Manager errors, generate an NSError if one is requested, then return nil
 		if (error) {
-			errorDescription = [NSString stringWithFormat: @"Apple Event Manager error: %@ (%i)", 
-															ASDescriptionForError(errorNumber), errorNumber];
+			errorDescription = [NSString stringWithFormat: @"Apple Event Manager error: %@ (%ld)",
+															ASDescriptionForError(errorNumber), (long)errorNumber];
 			errorInfo = [NSDictionary dictionaryWithObjectsAndKeys: 
 					errorDescription,						NSLocalizedDescriptionKey,
 					[NSNumber numberWithInt: errorNumber],	kASErrorNumberKey,
@@ -282,10 +283,10 @@ static ASEventAttributeDescription attributeKeys[] = {
 		if (error) {
 			errorString = [[replyData paramDescriptorForKeyword: keyErrorString] stringValue];
 			if (errorString)
-				errorDescription = [NSString stringWithFormat: @"Application error: %@ (%i)", errorString, errorNumber];
+				errorDescription = [NSString stringWithFormat: @"Application error: %@ (%ld)", errorString, (long)errorNumber];
 			else
-				errorDescription = [NSString stringWithFormat: @"Application error: %@ (%i)", 
-																ASDescriptionForError(errorNumber), errorNumber];
+				errorDescription = [NSString stringWithFormat: @"Application error: %@ (%ld)",
+																ASDescriptionForError(errorNumber), (long)errorNumber];
 			errorInfo = [NSMutableDictionary dictionaryWithObjectsAndKeys: 
 					errorDescription,						NSLocalizedDescriptionKey,
 					[NSNumber numberWithInt: errorNumber],	kASErrorNumberKey,
@@ -323,7 +324,7 @@ static ASEventAttributeDescription attributeKeys[] = {
 		if (resultType != typeWildCard) {
 			NSMutableArray *resultList;
 			NSAppleEventDescriptor *item;
-			int i, length;
+			NSInteger i, length;
 			resultList = [NSMutableArray array];
 			length = [result numberOfItems];
 			for (i = 1; i <= length; i++) {

--- a/objc-appscript/trunk/src/Appscript/objectrenderer.m
+++ b/objc-appscript/trunk/src/Appscript/objectrenderer.m
@@ -11,7 +11,7 @@
 +(NSString *)formatOSType:(OSType)code {
 	NSMutableString *str;
 	char c;
-	int i;
+	size_t i;
 	
 	code = CFSwapInt32HostToBig(code);
 	str = [NSMutableString stringWithCapacity: 16];

--- a/objc-appscript/trunk/src/Appscript/parser.h
+++ b/objc-appscript/trunk/src/Appscript/parser.h
@@ -14,7 +14,7 @@
 @interface ASParserDef : NSObject {
 	NSString *name;
 	OSType code;
-	unsigned hash;
+	NSUInteger hash;
 }
 
 - (id)initWithName:(NSString*)name_ code:(OSType)code_;

--- a/objc-appscript/trunk/src/Appscript/parser.m
+++ b/objc-appscript/trunk/src/Appscript/parser.m
@@ -26,7 +26,7 @@
 #define CHECK_CURSOR \
 	if (cursor > aeteSize) \
 		[NSException raise: @"Bad aete" \
-					format: @"Data ended prematurely (%i bytes expected, %i bytes read)", \
+					format: @"Data ended prematurely (%lu bytes expected, %lu bytes read)", \
 							aeteSize, cursor];
 
 
@@ -435,12 +435,12 @@
 	NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
 	NSEnumerator *enumerator;
 	NSString *code;
-	int i;
+	NSUInteger i;
 	
 	if ([aetes isKindOfClass: [NSAppleEventDescriptor class]]) {
 		if ([aetes descriptorType] != typeAEList)
 			aetes = [aetes coerceToDescriptorType: typeAEList];
-		for (i = 1; i <= [aetes numberOfItems]; i++)
+		for (i = 1; (NSInteger)i <= [aetes numberOfItems]; i++)
 			[self parseAETEDescriptor: [aetes descriptorAtIndex: i]];
 	} else if ([aetes isKindOfClass: [NSArray class]]) {
 		for (i = 0; i < [aetes count]; i++)

--- a/objc-appscript/trunk/src/Appscript/terminology.m
+++ b/objc-appscript/trunk/src/Appscript/terminology.m
@@ -168,7 +168,7 @@
 	OSType code;
 	NSAppleEventDescriptor *desc;
 	NSDictionary *defaultTypeByName;
-	unsigned len, i;
+	NSUInteger len, i;
 	
 	defaultTypeByName = [defaultTerms typeByNameTable];
 	len = [definitions count];
@@ -220,7 +220,7 @@
 						   codeTable:(NSMutableDictionary *)codeTable {
 	ASParserDef *parserDef;
 	NSString *name, *convertedName;
-	unsigned len, i;
+	NSUInteger len, i;
 	
 	len = [definitions count];
 	for (i = 0; i < len; i++) {
@@ -258,7 +258,7 @@
 	NSString *name, *convertedName, *parameterName;
 	NSDictionary *defaultCommandByName;
 	OSType eventClass, eventID;
-	unsigned len, i;
+	NSUInteger len, i;
 
 	defaultCommandByName = [defaultTerms commandByNameTable];
 	// To handle synonyms, if two commands have same name but different codes, only the first

--- a/objc-appscript/trunk/src/Appscript/utils.m
+++ b/objc-appscript/trunk/src/Appscript/utils.m
@@ -13,7 +13,7 @@ NSString *ASDescriptionForError(OSStatus err) {
 		if (errorString && ![errorString isEqual: @""])
 			return errorString;
 	}
-	return [NSString stringWithFormat: @"Mac OS error %i", err];
+	return [NSString stringWithFormat: @"Mac OS error %ld", (long)err];
 }
 
 


### PR DESCRIPTION
- One of these errors was causing a crash. I don't actually know which
  one. I had clang find all 64-bit warnings and fixed them the way it
  suggested, and the crash went away. I then gave them a once-over to
  make sure they all looked like good fixes, and left it at that.
