### PR TITLE
objc: Make sendMode work.

### DIFF
--- a/objc-appscript/trunk/src/Appscript/command.m
+++ b/objc-appscript/trunk/src/Appscript/command.m
@@ -178,22 +178,22 @@ fail:
 		if (!(considsAndIgnoresFlags && kAECaseConsiderMask))
 			[ignoreListDesc insertDescriptor: [NSAppleEventDescriptor descriptorWithEnumCode: kAECase] 
 									 atIndex: 0];
-		if (considsAndIgnoresFlags && kAEDiacriticIgnoreMask)
+		if (considsAndIgnoresFlags & kAEDiacriticIgnoreMask)
 			[ignoreListDesc insertDescriptor: [NSAppleEventDescriptor descriptorWithEnumCode: kAEDiacritic] 
 									 atIndex: 0];
-		if (considsAndIgnoresFlags && kAEWhiteSpaceIgnoreMask)
+		if (considsAndIgnoresFlags & kAEWhiteSpaceIgnoreMask)
 			[ignoreListDesc insertDescriptor: [NSAppleEventDescriptor descriptorWithEnumCode: kAEWhiteSpace] 
 									 atIndex: 0];
-		if (considsAndIgnoresFlags && kAEHyphensIgnoreMask)
+		if (considsAndIgnoresFlags & kAEHyphensIgnoreMask)
 			[ignoreListDesc insertDescriptor: [NSAppleEventDescriptor descriptorWithEnumCode: kAEHyphens] 
 									 atIndex: 0];
-		if (considsAndIgnoresFlags && kAEExpansionIgnoreMask)
+		if (considsAndIgnoresFlags & kAEExpansionIgnoreMask)
 			[ignoreListDesc insertDescriptor: [NSAppleEventDescriptor descriptorWithEnumCode: kAEExpansion] 
 									 atIndex: 0];
-		if (considsAndIgnoresFlags && kAEPunctuationIgnoreMask)
+		if (considsAndIgnoresFlags & kAEPunctuationIgnoreMask)
 			[ignoreListDesc insertDescriptor: [NSAppleEventDescriptor descriptorWithEnumCode: kAEPunctuation] 
 									 atIndex: 0];
-		if (considsAndIgnoresFlags && kASNumericStringsIgnoreMask)
+		if (considsAndIgnoresFlags & kASNumericStringsIgnoreMask)
 			[ignoreListDesc insertDescriptor: [NSAppleEventDescriptor descriptorWithEnumCode: kASNumericStrings] 
 									 atIndex: 0];
 		[AS_event setAttribute: ignoreListDesc forKeyword: enumConsiderations];
@@ -285,7 +285,7 @@ fail:
 	if (timeout != kAEDefaultTimeout)
 		result = [NSString stringWithFormat: @"[%@ timeout: %i]", result, timeout / 60];
 	if (sendMode != (kAEWaitReply | kAECanSwitchLayer)) {
-		if (sendMode & ~(kAEWaitReply | kAEQueueReply | kAENoReply) == kAECanSwitchLayer) {
+		if ((sendMode & ~(kAEWaitReply | kAEQueueReply | kAENoReply)) == kAECanSwitchLayer) {
 			if (sendMode & kAENoReply)
 				result = [NSString stringWithFormat: @"[%@ ignoreReply]", result];
 			if (sendMode & kAEQueueReply)

--- a/objc-appscript/trunk/src/Appscript/sendthreadsafe.c
+++ b/objc-appscript/trunk/src/Appscript/sendthreadsafe.c
@@ -359,7 +359,7 @@ OSStatus AEMSendMessageThreadSafe(
     assert(eventPtr != NULL);
     assert(replyPtr != NULL);
     
-	if (sendMode && kAEWaitReply) {
+	if (sendMode & kAEWaitReply) {
 		replyPort = MACH_PORT_NULL;
 		
 		// Set up the reply port if necessary.


### PR DESCRIPTION
- There are a few places that use `&&` instead of `&` to mask bits out
  of sendMode, which doesn't actually mask out the bits.
- Another place is missing parens, so it ends up comparing the last
  flag instead of the masked value.
- The net result is that changing the sendMode doesn't work in a
  variety of different cases.
