### PR TITLE
Add top-level setup.py to make pip install git+https work.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,50 @@
+try:
+	from setuptools import setup, Extension
+except ImportError:
+	print("Note: couldn't import setuptools so using distutils instead.")
+	from distutils.core import setup, Extension
+
+import os, sys
+
+if sys.version_info >= (3,0):
+	root_dir = 'py-appscript/trunk/appscript_3x'
+else:
+	root_dir = 'py-appscript/trunk/appscript_2x'
+
+
+setup(
+		name = "appscript",
+		version = "1.0.0",
+		description = "Control AppleScriptable applications from Python.",
+		url='http://appscript.sourceforge.net',
+		license='Public Domain',
+		platforms=['Mac OS X'],
+		ext_modules = [
+			Extension('aem.ae',
+				sources=[os.path.join(root_dir, 'ext/ae.c')],
+				extra_compile_args=['-DMAC_OS_X_VERSION_MIN_REQUIRED=MAC_OS_X_VERSION_10_4'],
+				extra_link_args=[
+						'-framework', 'CoreFoundation', 
+						'-framework', 'ApplicationServices',
+						'-framework', 'Carbon'],
+			),
+		],
+		packages = [
+			'aem',
+			'appscript',
+		],
+		py_modules=[
+			'mactypes',
+			'osax',
+		],
+		extra_path = "aeosa",
+		package_dir = {'': os.path.join(root_dir, 'lib')},
+		classifiers = [
+			'License :: Public Domain',
+			'Development Status :: 5 - Production/Stable',
+			'Operating System :: MacOS :: MacOS X',
+			'Programming Language :: Python :: 2',
+			'Programming Language :: Python :: 3',
+		],
+
+)


### PR DESCRIPTION
Updated releases to PyPI may never happen, and certainly won't be happening regularly in the near future. So, for people who need appscript, `pip install appscript` won't work. 

At present, to install appscript, you have to do this:

```
git clone https://github.com/mattneub/appscript.git
pip install ./py-appscript/trunk
```

Putting a setup.py at the top level means you only need this:

```
pip install git+https://github.com/mattneub/appscript
```

It would be also be slightly helpful for those who prefer to use easy_install, or to build and install manually—they'd still need two steps instead of one, but at least they wouldn't have to figure out the CVS structure of the py-appscript subproject. And it might even help whoever maintains the ports for MacPorts and Fink.

But they aren't the main motivation; pip is the way most Mac users get Python packages.
