### PR TITLE
Update objc-appscript/trunk/src/Appscript/codecs.m

### DIFF
--- a/objc-appscript/trunk/src/Appscript/codecs.m
+++ b/objc-appscript/trunk/src/Appscript/codecs.m
@@ -122,7 +122,7 @@
 			case 'q':
 				packAsSInt64:
 					sint64 = [anObject longLongValue];
-					if (sint64 >= 0x80000000 && sint64 < 0x7FFFFFFF)
+					if (sint64 <= -0x80000000 && sint64 < 0x7FFFFFFF)
 						goto packAsSInt32;
 					result = [NSAppleEventDescriptor descriptorWithDescriptorType: typeSInt64
 																			bytes: &sint64


### PR DESCRIPTION
The test for whether a long long will fit in an SInt32 is incorrect in - (NSAppleEventDescriptor *)pack:(id)anObject.

if (sint64 >= 0x80000000 && sint64 < 0x7FFFFFFF)

should be:

if (sint64 <= -0x80000000 && sint64 < 0x7FFFFFFF)
