### PR TITLE
Bump version number to 0.6.2

### DIFF
--- a/rb-appscript/trunk/rb-appscript.gemspec
+++ b/rb-appscript/trunk/rb-appscript.gemspec
@@ -1,6 +1,6 @@
 spec = Gem::Specification.new do |s|
 	s.name = "rb-appscript"
-	s.version = "0.6.1"
+	s.version = "0.6.2"
 	s.homepage = "http://appscript.sourceforge.net/"
 	s.authors = ["Hamish Sanderson"]
 	s.summary="Ruby appscript (rb-appscript) is a high-level, user-friendly Apple event bridge that allows you to control scriptable Mac OS X applications using ordinary Ruby scripts."


### PR DESCRIPTION
Howdy @mattneub!  :wave:

This Pull Request bumps the version number for this gem based on the fixes for Ruby 2.2.x that happened in #11.

I'm not sure if a patch-level bump conforms with the versioning conventions y'all are using, so feel free to change these numbers around!  I figured some sort of distinction between published versions of the gem would be helpful though.

If you are holding off until the path going forward is clearer (based on the tests/ownership conversation in #12) and want to close this out for now, I totally understand. 👍 
